### PR TITLE
Update readme: Use plist for workspace config and eglot-ensure to load eglot lazily

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Consider adding this to your configuration.
   :ensure t
   :hook (text-mode . (lambda ()
                        (require 'eglot-ltex)
-                       (call-interactively #'eglot)))
+                       (eglot-ensure)))
   :init
   (setq eglot-languagetool-server-path "path/to/ltex-ls-XX.X.X/"))
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [![CI](https://github.com/emacs-languagetool/eglot-ltex/actions/workflows/test.yml/badge.svg)](https://github.com/emacs-languagetool/eglot-ltex/actions/workflows/test.yml)
 
-`eglot` client leveraging [LTEX Language Server](https://github.com/valentjn/ltex-ls).
+`Eglot` client leveraging [LTEX Language Server](https://github.com/valentjn/ltex-ls).
 
 ## :floppy_disk: Quickstart
 
@@ -32,15 +32,16 @@ Consider adding this to your configuration.
 
 ## :wrench: Configuration
 
-Create `.dir-locals.el` file in the the project root directory.
+Create `.dir-locals.el` file in the project root directory to configure the ltex language server, for example:
 
 ```el
-((nil
-  (eglot-workspace-configuration
-   . ((ltex-ls . ((language . "en-US")))))))
+((nil .
+  ((eglot-workspace-configuration
+    . (:ltex-ls  (:language  "en-US"
+                  :additionalRules (:motherTongue "de-DE")))))))
 ```
 
-*P.S. See all possible configuration [here](https://valentjn.github.io/vscode-ltex/docs/settings.html).*
+You can find all possible ltex configuration options [here](https://valentjn.github.io/vscode-ltex/docs/settings.html). See the [Eglot manual](https://joaotavora.github.io/eglot/#JSONRPC-objects-in-Elisp) on how to translate the LSP options into the property-list format that Eglot requires.
 
 ## Contribute
 


### PR DESCRIPTION
This is adapted from my own eglot configuration for ltex, which I use with raw eglot without this package. But when I saw the readme I thought the examples could be updated.

As far as I see it this package is not really needed to use eglot with ltex, it's just convenience that offers some useful default-configuration. Maybe that should also be mentioned in the readme. You don't need extra packages in eglot for each language server.