### PR TITLE
Set ltex server type to tcpsocket

### DIFF
--- a/eglot-ltex.el
+++ b/eglot-ltex.el
@@ -78,7 +78,7 @@ This file is use to activate the language server."
 
 (defun eglot-ltex--server-command ()
   "Generate startup command for LTEX language server."
-  (list (eglot-ltex--server-entry)))
+  (list (eglot-ltex--server-entry) "--server-type" "TcpSocket" "--port" :autoport))
 
 (add-to-list 'eglot-server-programs
              `(,eglot-ltex-active-modes . ,(eglot-ltex--server-command)))


### PR DESCRIPTION
I was having the same issue described by #9, and this fixes the problem by telling ltex to use TCP instead of standard input and standard output. I couldn't figure out though if problem with the standard stream is eglot, emacs, or ltex? 