### PR TITLE
Support for AUCTeX and improved configurability

### DIFF
--- a/eglot-ltex.el
+++ b/eglot-ltex.el
@@ -90,7 +90,7 @@ This file is use to activate the language server."
       ("" (executable-find program-basename))
       (_ (user-error "eglot-ltex-server-path is invalid or points to a nonexistant file: " eglot-ltex-server-path)))))
 
-(defun eglot-ltex--server-program (interactive project)
+(defun eglot-ltex--server-program (_interactive _project)
   (pcase eglot-ltex-communication-channel
     ('stdio `(,(eglot-ltex--server-entry)))
     ('tcp `(,(eglot-ltex--server-entry) "--server-type" "TcpSocket" "--port" :autoport))


### PR DESCRIPTION
This PR addresses two issues that I ran into when setting up eglot-ltex:

1. It was not possible to specify an explicit path to the executable, only an installation root. The ability to do the former is desirable for numerous reasons, including both reduced dependency on the directory structure and file names of another project, and that in certain cases the binary may be installed in a different location or with a different name (e.g. `ltex-ls-plus`).
2. When using AUCTeX, eglot would not select the server because it was not marked as supporting `LaTeX-mode`, which is distinct from `latex-mode`.

Additionally, I have added some code to detect the server if no explicit file or directory is given, and it is on the path.